### PR TITLE
ROS2 Foxy Port

### DIFF
--- a/ublox_msgs/CMakeLists.txt
+++ b/ublox_msgs/CMakeLists.txt
@@ -103,17 +103,26 @@ rosidl_generate_interfaces(${PROJECT_NAME}
     std_msgs
 )
 
-include_directories(include)
+# Generate library target
 add_library(${PROJECT_NAME}_lib SHARED src/ublox_msgs.cpp)
 ament_target_dependencies(${PROJECT_NAME}_lib
   "ublox_serialization"
 )
+target_include_directories(${PROJECT_NAME}_lib
+  PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+
+### Install library
 rosidl_target_interfaces(${PROJECT_NAME}_lib ${PROJECT_NAME} "rosidl_typesupport_cpp")
+ament_export_targets(${PROJECT_NAME}_lib HAS_LIBRARY_TARGET)
 ament_export_include_directories(include)
 ament_export_libraries(${PROJECT_NAME}_lib)
 ament_export_dependencies(rosidl_default_runtime std_msgs sensor_msgs ublox_serialization)
 
 install(TARGETS ${PROJECT_NAME}_lib
+  EXPORT ${PROJECT_NAME}_lib
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin


### PR DESCRIPTION
# Ublox Foxy Port

## Summary

Using the Dashing version of the ROS2 port, the `ublox_gps` the following error message will occur:
```Starting >>> ublox_gps                                                                                                                                                                                             
[Processing: ublox_gps]                                                                                                                                                                                            
--- stderr: ublox_gps                                                                                                                                                                                              
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::RxmRTCM_<std::allocator<void> > >::keys_'                                                                                    
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::NavPOSLLH_<std::allocator<void> > >::keys_'                                                                                  
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::CfgGNSS_<std::allocator<void> > >::keys_'                                                                                    
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::AidEPH_<std::allocator<void> > >::keys_'                                                                                     
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::RxmALM_<std::allocator<void> > >::keys_'                                                                                     
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::EsfMEAS_<std::allocator<void> > >::keys_'                                                                                    
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::HnrPVT_<std::allocator<void> > >::keys_'                                                                                     
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::EsfINS_<std::allocator<void> > >::keys_'                                                                                     
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::RxmSFRBX_<std::allocator<void> > >::keys_'                                                                                   
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::NavPVT7_<std::allocator<void> > >::keys_'                                                                                    
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::EsfRAW_<std::allocator<void> > >::keys_'                                                                                     
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::NavRELPOSNED_<std::allocator<void> > >::keys_'                                                                               
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::NavSOL_<std::allocator<void> > >::keys_'                                                                                     
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::Ack_<std::allocator<void> > >::keys_'                                                                                        
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::NavPOSECEF_<std::allocator<void> > >::keys_'                                                                                 
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::Inf_<std::allocator<void> > >::keys_'                                                                                        
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::TimTM2_<std::allocator<void> > >::keys_'                                                                                     
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::NavATT_<std::allocator<void> > >::keys_'                                                                                     
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::NavSVINFO_<std::allocator<void> > >::keys_'                                                                                  
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::NavSTATUS_<std::allocator<void> > >::keys_'                                                                                  
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::UpdSOSAck_<std::allocator<void> > >::keys_'                                                                                  
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::MonVER_<std::allocator<void> > >::keys_'                                                                                     
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::RxmSFRB_<std::allocator<void> > >::keys_'                                                                                    
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::RxmEPH_<std::allocator<void> > >::keys_'                                                                                     
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::NavVELNED_<std::allocator<void> > >::keys_'                                                                                  
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::RxmRAW_<std::allocator<void> > >::keys_'                                                                                     
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::RxmRAWX_<std::allocator<void> > >::keys_'                                                                                    
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::NavSAT_<std::allocator<void> > >::keys_'                                                                                     
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::NavRELPOSNED9_<std::allocator<void> > >::keys_'                                                                              
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::CfgPRT_<std::allocator<void> > >::keys_'                                                                                     
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::NavSVIN_<std::allocator<void> > >::keys_'                                                                                    
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::NavCLOCK_<std::allocator<void> > >::keys_'                                                                                   
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::AidALM_<std::allocator<void> > >::keys_'                                                                                     
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::NavPVT_<std::allocator<void> > >::keys_'                                                                                     
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::MonHW_<std::allocator<void> > >::keys_'                                                                                      
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::EsfSTATUS_<std::allocator<void> > >::keys_'                                                                                  
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::AidHUI_<std::allocator<void> > >::keys_'                                                                                     
/usr/bin/ld: libublox_gps.so: undefined reference to `ublox::Message<ublox_msgs::msg::MonHW6_<std::allocator<void> > >::keys_'                                                                                     
collect2: error: ld returned 1 exit status                                                                                                                                                                         
make[2]: *** [CMakeFiles/ublox_gps_node.dir/build.make:197: ublox_gps_node] Error 1                                                                                                                                
make[1]: *** [CMakeFiles/Makefile2:109: CMakeFiles/ublox_gps_node.dir/all] Error 2                                                                                                                                 
make: *** [Makefile:141: all] Error 2                                                                                                                                                                              
---                                                                                                                                                                                                                
Failed   <<< ublox_gps [32.9s, exited with code 2]                                                                                                                                                                 
                                                                                                                                                                                                                   
Summary: 0 packages finished [33.1s]                                                                                                                                                                               
  1 package failed: ublox_gps                                                                                                                                                                                      
  1 package had stderr output: ublox_gps
```
Some CMake syntax and semantics have changed since earlier ROS2 versions.
 - Reference "modern" CMake style for building and exporting libraries

The following references were used to fix the issue:
1. [Properly including include directories and for exporting libraries](https://index.ros.org/doc/ros2/Releases/Release-Foxy-Fitzroy/#classic-cmake-vs-modern-cmake)
2. [export interface to export target](https://index.ros.org/doc/ros2/Releases/Release-Foxy-Fitzroy/#ament-export-interfaces-replaced-by-ament-export-targets)

## Testing

You should be able to compile this package using colcon in a ROS2 Foxy environment

There aren't any tests included in this package so once again hard to test though I am currently porting the `gnss_poser` package (which depends on ublox) to ROS2 Foxy so that could be used to test to make sure that all the libraries have been compiled properly.  