### PR TITLE
Changed ROS_FATAL/ERROR to WARN

### DIFF
--- a/ublox_gps/include/ublox_gps/async_worker.h
+++ b/ublox_gps/include/ublox_gps/async_worker.h
@@ -165,12 +165,12 @@ bool AsyncWorker<StreamT>::send(const unsigned char *data,
                                 const unsigned int size) {
   ScopedLock lock(write_mutex_);
   if (size == 0) {
-    ROS_ERROR("Ublox AsyncWorker::send: Size of message to send is 0");
+    ROS_WARN("Ublox AsyncWorker::send: Size of message to send is 0");
     return true;
   }
 
   if (out_.capacity() - out_.size() < size) {
-    ROS_ERROR(
+    ROS_WARN(
         "Ublox AsyncWorker::send: Output buffer too full to send message");
     return false;
   }
@@ -219,7 +219,7 @@ void AsyncWorker<StreamT>::readEnd(const boost::system::error_code &error,
                                    std::size_t bytes_transfered) {
   ScopedLock lock(read_mutex_);
   if (error) {
-    ROS_ERROR_THROTTLE(5.0, "U-Blox ASIO input buffer read error: %s, %li",
+    ROS_WARN_THROTTLE(5.0, "U-Blox ASIO input buffer read error: %s, %li",
               error.message().c_str(), bytes_transfered);
   } else if (bytes_transfered > 0) {
     in_buffer_size_ += bytes_transfered;
@@ -256,7 +256,7 @@ void AsyncWorker<StreamT>::doClose() {
   boost::system::error_code error;
   stream_->close(error);
   if (error)
-    ROS_ERROR_STREAM(
+    ROS_WARN_STREAM(
         "Error while closing the AsyncWorker stream: " << error.message());
 }
 

--- a/ublox_gps/include/ublox_gps/gps.h
+++ b/ublox_gps/include/ublox_gps/gps.h
@@ -521,7 +521,7 @@ bool Gps::configure(const ConfigT &message, bool wait) {
   std::vector<unsigned char> out(kWriterSize);
   ublox::Writer writer(out.data(), out.size());
   if (!writer.write(message)) {
-    ROS_ERROR("Failed to encode config message 0x%02x / 0x%02x",
+    ROS_WARN("Failed to encode config message 0x%02x / 0x%02x",
               message.CLASS_ID, message.MESSAGE_ID);
     return false;
   }

--- a/ublox_gps/src/gps.cpp
+++ b/ublox_gps/src/gps.cpp
@@ -100,7 +100,7 @@ void Gps::processNack(const ublox_msgs::Ack &m) {
   ack.msg_id = m.msgID;
   // store the ack atomically
   ack_.store(ack, boost::memory_order_seq_cst);
-  ROS_ERROR("U-blox: received NACK: 0x%02x / 0x%02x", m.clsID, m.msgID);
+  ROS_WARN("U-blox: received NACK: 0x%02x / 0x%02x", m.clsID, m.msgID);
 }
 
 void Gps::processUpdSosAck(const ublox_msgs::UpdSOS_Ack &m) {
@@ -113,7 +113,7 @@ void Gps::processUpdSosAck(const ublox_msgs::UpdSOS_Ack &m) {
     ack_.store(ack, boost::memory_order_seq_cst);
     ROS_DEBUG_COND(ack.type == ACK && debug >= 2,
                    "U-blox: received UPD SOS Backup ACK");
-    if (ack.type == NACK) ROS_ERROR("U-blox: received UPD SOS Backup NACK");
+    if (ack.type == NACK) ROS_WARN("U-blox: received UPD SOS Backup NACK");
   }
 }
 
@@ -205,12 +205,12 @@ void Gps::resetSerial(std::string port) {
   std::vector<uint8_t> payload;
   payload.push_back(CfgPRT::PORT_ID_UART1);
   if (!poll(CfgPRT::CLASS_ID, CfgPRT::MESSAGE_ID, payload)) {
-    ROS_ERROR("Resetting Serial Port: Could not poll UART1 CfgPRT");
+    ROS_WARN("Resetting Serial Port: Could not poll UART1 CfgPRT");
     return;
   }
   CfgPRT prt;
   if (!read(prt, default_timeout_)) {
-    ROS_ERROR("Resetting Serial Port: Could not read polled UART1 CfgPRT %s",
+    ROS_WARN("Resetting Serial Port: Could not read polled UART1 CfgPRT %s",
               "message");
     return;
   }
@@ -349,11 +349,11 @@ bool Gps::disableUart1(CfgPRT &prev_config) {
   std::vector<uint8_t> payload;
   payload.push_back(CfgPRT::PORT_ID_UART1);
   if (!poll(CfgPRT::CLASS_ID, CfgPRT::MESSAGE_ID, payload)) {
-    ROS_ERROR("disableUart: Could not poll UART1 CfgPRT");
+    ROS_WARN("disableUart: Could not poll UART1 CfgPRT");
     return false;
   }
   if (!read(prev_config, default_timeout_)) {
-    ROS_ERROR("disableUart: Could not read polled UART1 CfgPRT message");
+    ROS_WARN("disableUart: Could not read polled UART1 CfgPRT message");
     return false;
   }
   // Keep original settings, but disable in/out
@@ -398,7 +398,7 @@ bool Gps::configRtcm(std::vector<uint8_t> ids, std::vector<uint8_t> rates) {
   for (size_t i = 0; i < ids.size(); ++i) {
     ROS_DEBUG("Setting RTCM %d Rate %u", ids[i], rates[i]);
     if (!setRate(ublox_msgs::Class::RTCM, (uint8_t)ids[i], rates[i])) {
-      ROS_ERROR("Could not set RTCM %d to rate %u", ids[i], rates[i]);
+      ROS_WARN("Could not set RTCM %d to rate %u", ids[i], rates[i]);
       return false;
     }
   }
@@ -419,7 +419,7 @@ bool Gps::configTmode3Fixed(bool lla_flag, std::vector<float> arp_position,
                             std::vector<int8_t> arp_position_hp,
                             float fixed_pos_acc) {
   if (arp_position.size() != 3 || arp_position_hp.size() != 3) {
-    ROS_ERROR("Configuring TMODE3 to Fixed: size of position %s",
+    ROS_WARN("Configuring TMODE3 to Fixed: size of position %s",
               "& arp_position_hp args must be 3");
     return false;
   }

--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -256,7 +256,7 @@ void UbloxNode::pollMessages(const ros::TimerEvent &event) {
 
 void UbloxNode::printInf(const ublox_msgs::Inf &m, uint8_t id) {
   if (id == ublox_msgs::Message::INF::ERROR)
-    ROS_ERROR_STREAM("INF: " << std::string(m.str.begin(), m.str.end()));
+    ROS_WARN_STREAM("INF: " << std::string(m.str.begin(), m.str.end()));
   else if (id == ublox_msgs::Message::INF::WARNING)
     ROS_WARN_STREAM("INF: " << std::string(m.str.begin(), m.str.end()));
   else if (id == ublox_msgs::Message::INF::DEBUG)
@@ -491,10 +491,10 @@ bool UbloxNode::configureUblox() {
       ROS_DEBUG("Saving the u-blox configuration, mask %u, device %u",
                 save_.saveMask, save_.deviceMask);
       if (!gps.configure(save_))
-        ROS_ERROR("u-blox unable to save configuration to non-volatile memory");
+        ROS_WARN("u-blox unable to save configuration to non-volatile memory");
     }
   } catch (std::exception &e) {
-    ROS_FATAL("Error configuring u-blox: %s", e.what());
+    ROS_WARN("Error configuring u-blox: %s", e.what());
     return false;
   }
   return true;
@@ -1127,7 +1127,7 @@ void UbloxFirmware8::getRosParams() {
 bool UbloxFirmware8::configureUblox() {
   if (clear_bbr_) {
     // clear flash memory
-    if (!gps.clearBbr()) ROS_ERROR("u-blox failed to clear flash memory");
+    if (!gps.clearBbr()) ROS_WARN("u-blox failed to clear flash memory");
   }
   //
   // Configure the GNSS, only if the configuration is different
@@ -1557,7 +1557,7 @@ bool HpgRefProduct::configureUblox() {
                                "before setting TMODE3 to survey-in.");
     // As recommended in the documentation, first disable, then set to survey in
     if (!gps.disableTmode3())
-      ROS_ERROR("Failed to disable TMODE3 before setting to survey-in.");
+      ROS_WARN("Failed to disable TMODE3 before setting to survey-in.");
     else
       mode_ = DISABLED;
     // Set to Survey in mode
@@ -1599,11 +1599,11 @@ bool HpgRefProduct::setTimeMode() {
   // Set the Measurement & nav rate to user config
   // (survey-in sets nav_rate to 1 Hz regardless of user setting)
   if (!gps.configRate(meas_rate, nav_rate))
-    ROS_ERROR("Failed to set measurement rate to %d ms %s %d", meas_rate,
+    ROS_WARN("Failed to set measurement rate to %d ms %s %d", meas_rate,
               "navigation rate to ", nav_rate);
   // Enable the RTCM out messages
   if (!gps.configRtcm(rtcm_ids, rtcm_rates)) {
-    ROS_ERROR("Failed to configure RTCM IDs");
+    ROS_WARN("Failed to configure RTCM IDs");
     return false;
   }
   return true;

--- a/ublox_gps/src/raw_data_pa.cpp
+++ b/ublox_gps/src/raw_data_pa.cpp
@@ -82,13 +82,13 @@ void RawDataStreamPa::initialize() {
   if (!file_dir_.empty()) {
     struct stat stat_info;
     if (stat(file_dir_.c_str(), &stat_info) != 0) {
-      ROS_ERROR(
+      ROS_WARN(
           "Can't log raw data to file. "
           "Directory \"%s\" does not exist.",
           file_dir_.c_str());
 
     } else if ((stat_info.st_mode & S_IFDIR) != S_IFDIR) {
-      ROS_ERROR(
+      ROS_WARN(
           "Can't log raw data to file. "
           "\"%s\" exists, but is not a directory.",
           file_dir_.c_str());
@@ -131,7 +131,7 @@ void RawDataStreamPa::initialize() {
         file_handle_.open(file_name_);
         ROS_INFO("Logging raw data to file \"%s\"", file_name_.c_str());
       } catch (const std::exception &e) {
-        ROS_ERROR(
+        ROS_WARN(
             "Can't log raw data to file. "
             "Can't create file \"%s\".",
             file_name_.c_str());

--- a/ublox_msgs/include/ublox/serialization/ublox_msgs.h
+++ b/ublox_msgs/include/ublox/serialization/ublox_msgs.h
@@ -114,7 +114,7 @@ struct Serializer<ublox_msgs::CfgGNSS_<ContainerAllocator> > {
   static void write(uint8_t *data, uint32_t size,
                     typename CallTraits::param_type m) {
     if (m.blocks.size() != m.numConfigBlocks) {
-      ROS_ERROR("CfgGNSS numConfigBlocks must equal blocks size");
+      ROS_WARN("CfgGNSS numConfigBlocks must equal blocks size");
     }
     ros::serialization::OStream stream(data, size);
     stream.next(m.msgVer);
@@ -252,7 +252,7 @@ struct Serializer<ublox_msgs::NavDGPS_<ContainerAllocator> > {
   static void write(uint8_t *data, uint32_t size,
                     typename CallTraits::param_type m) {
     if (m.sv.size() != m.numCh) {
-      ROS_ERROR("NavDGPS numCh must equal sv size");
+      ROS_WARN("NavDGPS numCh must equal sv size");
     }
     ros::serialization::OStream stream(data, size);
     stream.next(m.iTOW);
@@ -297,7 +297,7 @@ struct Serializer<ublox_msgs::NavSBAS_<ContainerAllocator> > {
   static void write(uint8_t *data, uint32_t size,
                     typename CallTraits::param_type m) {
     if (m.sv.size() != m.cnt) {
-      ROS_ERROR("NavSBAS cnt must equal sv size");
+      ROS_WARN("NavSBAS cnt must equal sv size");
     }
     ros::serialization::OStream stream(data, size);
     stream.next(m.iTOW);
@@ -339,7 +339,7 @@ struct Serializer<ublox_msgs::NavSAT_<ContainerAllocator> > {
   static void write(uint8_t *data, uint32_t size,
                     typename CallTraits::param_type m) {
     if (m.sv.size() != m.numSvs) {
-      ROS_ERROR("NavSAT numSvs must equal sv size");
+      ROS_WARN("NavSAT numSvs must equal sv size");
     }
     ros::serialization::OStream stream(data, size);
     stream.next(m.iTOW);
@@ -378,7 +378,7 @@ struct Serializer<ublox_msgs::NavSVINFO_<ContainerAllocator> > {
   static void write(uint8_t *data, uint32_t size,
                     typename CallTraits::param_type m) {
     if (m.sv.size() != m.numCh) {
-      ROS_ERROR("NavSVINFO numCh must equal sv size");
+      ROS_WARN("NavSVINFO numCh must equal sv size");
     }
     ros::serialization::OStream stream(data, size);
     stream.next(m.iTOW);
@@ -417,7 +417,7 @@ struct Serializer<ublox_msgs::RxmRAW_<ContainerAllocator> > {
   static void write(uint8_t *data, uint32_t size,
                     typename CallTraits::param_type m) {
     if (m.sv.size() != m.numSV) {
-      ROS_ERROR("RxmRAW numSV must equal sv size");
+      ROS_WARN("RxmRAW numSV must equal sv size");
     }
     ros::serialization::OStream stream(data, size);
     stream.next(m.rcvTOW);
@@ -459,7 +459,7 @@ struct Serializer<ublox_msgs::RxmRAWX_<ContainerAllocator> > {
   static void write(uint8_t *data, uint32_t size,
                     typename CallTraits::param_type m) {
     if (m.meas.size() != m.numMeas) {
-      ROS_ERROR("RxmRAWX numMeas must equal meas size");
+      ROS_WARN("RxmRAWX numMeas must equal meas size");
     }
     ros::serialization::OStream stream(data, size);
     stream.next(m.rcvTOW);
@@ -505,7 +505,7 @@ struct Serializer<ublox_msgs::RxmSFRBX_<ContainerAllocator> > {
   static void write(uint8_t *data, uint32_t size,
                     typename CallTraits::param_type m) {
     if (m.dwrd.size() != m.numWords) {
-      ROS_ERROR("RxmSFRBX numWords must equal dwrd size");
+      ROS_WARN("RxmSFRBX numWords must equal dwrd size");
     }
     ros::serialization::OStream stream(data, size);
     stream.next(m.gnssId);
@@ -548,7 +548,7 @@ struct Serializer<ublox_msgs::RxmSVSI_<ContainerAllocator> > {
   static void write(uint8_t *data, uint32_t size,
                     typename CallTraits::param_type m) {
     if (m.sv.size() != m.numSV) {
-      ROS_ERROR("RxmSVSI numSV must equal sv size");
+      ROS_WARN("RxmSVSI numSV must equal sv size");
     }
     ros::serialization::OStream stream(data, size);
     stream.next(m.iTOW);
@@ -859,7 +859,7 @@ struct Serializer<ublox_msgs::EsfSTATUS_<ContainerAllocator> > {
   static void write(uint8_t *data, uint32_t size,
                     typename CallTraits::param_type m) {
     if (m.sens.size() != m.numSens) {
-      ROS_ERROR("Writing EsfSTATUS message: numSens must equal size of sens");
+      ROS_WARN("Writing EsfSTATUS message: numSens must equal size of sens");
     }
     ros::serialization::OStream stream(data, size);
     stream.next(m.iTOW);

--- a/ublox_serialization/include/ublox/serialization.h
+++ b/ublox_serialization/include/ublox/serialization.h
@@ -346,7 +346,7 @@ class Writer {
     // Check for buffer overflow
     uint32_t length = Serializer<T>::serializedLength(message);
     if (size_ < length + options_.wrapper_length()) {
-      ROS_ERROR("u-blox write buffer overflow. Message %u / %u not written",
+      ROS_WARN("u-blox write buffer overflow. Message %u / %u not written",
                 class_id, message_id);
       return false;
     }
@@ -368,7 +368,7 @@ class Writer {
   bool write(const uint8_t *message, uint32_t length, uint8_t class_id,
              uint8_t message_id) {
     if (size_ < length + options_.wrapper_length()) {
-      ROS_ERROR("u-blox write buffer overflow. Message %u / %u not written",
+      ROS_WARN("u-blox write buffer overflow. Message %u / %u not written",
                 class_id, message_id);
       return false;
     }


### PR DESCRIPTION
## PRの種類

- [ ] 新機能
- [ ] 既存機能の性能向上
- [x] バグフィックス

## Jiraリンク
https://tier4.atlassian.net/browse/AWIV-819
## 変更概要

現時点でGNSSが自動走行中止の要因にはなりえない。このためROS_FATALもしくはROS_ERRORで出力されていたものを、全てROS_WARNに変更

## レビュー方法

起動中にGNSSのUSBケーブルを抜く

## 動作確認結果
F9P実機にてROS_WARNとして出力されていることを確認
![image](https://user-images.githubusercontent.com/56018518/97572420-89a2dd00-1a2b-11eb-81fa-8bf1c881b830.png)


## その他

- [] [リリースノート](https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416)への記載
