### PR TITLE
Change measurement rate setting

### DIFF
--- a/ublox_gps/src/node.cpp
+++ b/ublox_gps/src/node.cpp
@@ -452,12 +452,6 @@ bool UbloxNode::configureUblox() {
       if (set_usb_) {
         gps.configUsb(usb_tx_, usb_in_, usb_out_);
       }
-      if (!gps.configRate(meas_rate, nav_rate)) {
-        std::stringstream ss;
-        ss << "Failed to set measurement rate to " << meas_rate
-           << "ms and navigation rate to " << nav_rate;
-        throw std::runtime_error(ss.str());
-      }
       // If device doesn't have SBAS, will receive NACK (causes exception)
       if (supportsGnss("SBAS")) {
         if (!gps.configSbas(enable_sbas_, sbas_usage_, max_sbas_)) {
@@ -486,6 +480,12 @@ bool UbloxNode::configureUblox() {
       for (int i = 0; i < components_.size(); i++) {
         if (!components_[i]->configureUblox()) return false;
       }
+    }
+    if (!gps.configRate(meas_rate, nav_rate)) {
+      std::stringstream ss;
+      ss << "Failed to set measurement rate to " << meas_rate
+          << "ms and navigation rate to " << nav_rate;
+      throw std::runtime_error(ss.str());
     }
     if (save_.saveMask != 0) {
       ROS_DEBUG("Saving the u-blox configuration, mask %u, device %u",


### PR DESCRIPTION
## PRの種類

- [ ] 新機能
- [ ] 既存機能の性能向上
- [x] バグフィックス

## Jiraリンク

## 変更概要
設定ファイル内の出力レート設定が5Hzになっているにも関わらず、実車両で1Hzしか出ない現象が確認された。
config_on_startupがfalseの際にレート変更を行わないようになっていたため、設定ファイルの出力レートが反映されるよう修正した

## レビュー方法

出力レートが1Hzに設定されているGNSS受信機を接続した状態で本ドライバを起動し、メッセージが5Hzで出力される/受信機の出力レート設定が５Hzに変更されている

## 動作確認結果
本ドライバ起動前にu-centerで出力レートが1Hzに設定されていることを確認し、ドライバを起動するとメッセージが５Hzで出力され、かつu-centerでで出力レートが5Hzに設定されていることを確認
![image](https://user-images.githubusercontent.com/56018518/104319489-49300700-5524-11eb-84eb-a03196bfa5a9.png)


## その他

- [] [リリースノート](https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416)への記載
